### PR TITLE
Fix package-buffer-info() complains "lacks a file header"

### DIFF
--- a/uv.el
+++ b/uv.el
@@ -1,4 +1,4 @@
-;;; uv --- An interface for the uv python package manager -*- lexical-binding: t; -*-
+;;; uv.el --- An interface for the uv python package manager -*- lexical-binding: t; -*-
 
 ;; Author: Johannes Mueller <github@johannes-mueller.org>
 ;; URL: https://github.com/johannes-mueller/uv.el


### PR DESCRIPTION
Hi, 
The `(package-buffer-info)` complains "lacks a file header", here is the backtrace:
```
Installing packages ..
Debugger entered -- Lisp error: (error "Package lacks a file header")
signal(error ("Package lacks a file header"))
error ("Package lacks a file header")
package-buffer-info()
quelpa-get-package-desc("~/.emacs.d/quelpa/packages/uv.el")
```
This PR add the `.el` on head line to satisfy  emacs' requirement. 
Please approve it. Thank you!